### PR TITLE
standalone mtp complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ BIBO standalone implementation
 - [x] user can deposit token into mtp
 - [x] user can borrow token in mtp
 - [x] user can withdraw token from mtp
-- [ ] user can interact with token functions via mtp
+- [x] user can interact with token functions via mtp
 
 ```
 npm i

--- a/contracts/mtp/StandaloneMTP.sol
+++ b/contracts/mtp/StandaloneMTP.sol
@@ -96,7 +96,6 @@ contract StandaloneMTP is Initializable, Ownable {
       if eq(result, 0) {
         revert(0, 0)
       }
-      //answer := mload(ptr)
       mstore(0x40, add(ptr, 0x24))
     }
   }

--- a/contracts/mtp/StandaloneMTP.sol
+++ b/contracts/mtp/StandaloneMTP.sol
@@ -21,6 +21,7 @@ contract StandaloneMTP is Initializable, Ownable {
   bytes32[] public uuids;
 
   IERC721Full public ERC721Interface;
+  address private _contract;
 
   function initialize() public initializer {
     Ownable.initialize(msg.sender);
@@ -56,7 +57,7 @@ contract StandaloneMTP is Initializable, Ownable {
     require(!tokens[uuid]._withdraw, "Token was withdrawed");
     require(
       msg.sender != tokens[uuid]._latest_holder,
-      "Call must not be current holder"
+      "Caller must not be current holder"
     );
     tokens[uuid]._latest_holder = msg.sender;
   }
@@ -73,7 +74,39 @@ contract StandaloneMTP is Initializable, Ownable {
     );
   }
 
+  function interact(
+    address contract_address,
+    string memory function_call,
+    bytes32 uuid
+  ) public {
+    require(!tokens[uuid]._withdraw, "Token was withdrawed");
+    require(
+      tokens[uuid]._latest_holder == msg.sender,
+      "Caller must be current holder"
+    );
+
+    _setDC(contract_address);
+    bytes4 sig = bytes4(keccak256(bytes(function_call)));
+    uint256 val = tokens[uuid]._token_id;
+    assembly {
+      let ptr := mload(0x40)
+      mstore(ptr, sig)
+      mstore(add(ptr, 0x04), val)
+      let result := call(15000, sload(_contract_slot), 0, ptr, 0x24, ptr, 0x20)
+      if eq(result, 0) {
+        revert(0, 0)
+      }
+      //answer := mload(ptr)
+      mstore(0x40, add(ptr, 0x24))
+    }
+  }
+
   function getAlluuids() public view returns (uint256) {
     return uuids.length;
+  }
+
+  // private function to set contract address for interact()
+  function _setDC(address _contract_address) private {
+    _contract = _contract_address;
   }
 }

--- a/contracts/nft/NFT.sol
+++ b/contracts/nft/NFT.sol
@@ -1,30 +1,39 @@
 pragma solidity ^0.5.12;
 
-import '@openzeppelin/upgrades/contracts/Initializable.sol';
-import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/ERC721Full.sol';
-import '@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/ERC721Mintable.sol';
+import "@openzeppelin/upgrades/contracts/Initializable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/ERC721Full.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/ERC721Mintable.sol";
+
 
 contract NFT is Initializable, ERC721Full, ERC721Mintable {
+  mapping(uint256 => uint256) private _counts;
 
-  mapping(uint256=>uint) private _counts;
-  function initialize(string memory name, string memory symbol) public initializer {
+  function initialize(string memory name, string memory symbol)
+    public
+    initializer
+  {
     ERC721.initialize();
     ERC721Enumerable.initialize();
-    ERC721Metadata.initialize(name,symbol);
+    ERC721Metadata.initialize(name, symbol);
     ERC721Mintable.initialize(msg.sender);
   }
 
   //function mintUniuqeToken()public{
-    //ERC721Mintable.mint(msg.sender, ERC721Enumerable.totalSupply());
+  //ERC721Mintable.mint(msg.sender, ERC721Enumerable.totalSupply());
   //}
 
-  function increment(uint256 tokenId)public{
-    if (ERC721.ownerOf(tokenId) == msg.sender){
-      _counts[tokenId] += 1;
-    }
+  function increment(uint256 tokenId) public {
+    require(ERC721.ownerOf(tokenId) == msg.sender, "Must be token owner");
+    _counts[tokenId] += 1;
   }
 
-  function getCounts(uint256 tokenId) public view returns(uint){
+  function decrement(uint256 tokenId) public {
+    require(ERC721.ownerOf(tokenId) == msg.sender, "Must be token owner");
+    require(_counts[tokenId] >= 1, "Count must be greater or equal to 1");
+    _counts[tokenId] -= 1;
+  }
+
+  function getCounts(uint256 tokenId) public view returns (uint256) {
     return _counts[tokenId];
   }
 }


### PR DESCRIPTION
added interaction function in StandaloneMTP, users can now borrow token in mtp and interact with token functions via **interact( )** function call.

```
interact(address contract_address, string function_call, bytes uuid)
```
- contract_address is the ERC721 token contract address
- function_call is string representation of the function call in ERC721 token contract
- uuid is bytes32 return from mtp getAlluuids( )

a sample call from web3 looks like this:

```
const uuids = await this.mtp.getAlluuids();
      await this.mtp.interact(
        await this.token.address,
        "increment(uint256)",
        uuids[0],
        {
          from: alice
        }
      );
```