### PR TITLE
added dynamic params for mtp interact( )

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ BIBO standalone implementation
 - [x] user can borrow token in mtp
 - [x] user can withdraw token from mtp
 - [x] user can interact with token functions via mtp
-- [ ] convert interact function to support dynamic params
+- [x] convert interact function to support dynamic params
+- [ ] interact only supports uint256 params, convert it to support other types
 
 ```
 npm i

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ BIBO standalone implementation
 - [x] user can borrow token in mtp
 - [x] user can withdraw token from mtp
 - [x] user can interact with token functions via mtp
+- [ ] convert interact function to support dynamic params
 
 ```
 npm i

--- a/contracts/mtp/StandaloneMTP.sol
+++ b/contracts/mtp/StandaloneMTP.sol
@@ -88,16 +88,17 @@ contract StandaloneMTP is Initializable, Ownable {
     _setDC(contract_address);
     bytes4 sig = bytes4(keccak256(bytes(function_call)));
     uint256 val = tokens[uuid]._token_id;
-    assembly {
-      let ptr := mload(0x40)
-      mstore(ptr, sig)
-      mstore(add(ptr, 0x04), val)
-      let result := call(15000, sload(_contract_slot), 0, ptr, 0x24, ptr, 0x20)
-      if eq(result, 0) {
-        revert(0, 0)
-      }
-      mstore(0x40, add(ptr, 0x24))
-    }
+    _contract.call(abi.encodePacked(sig, val));
+    //assembly {
+    //let ptr := mload(0x40)
+    //mstore(ptr, sig)
+    //mstore(add(ptr, 0x04), val)
+    //let result := call(15000, sload(_contract_slot), 0, ptr, 0x24, ptr, 0x20)
+    //if eq(result, 0) {
+    //revert(0, 0)
+    //}
+    //mstore(0x40, add(ptr, 0x24))
+    //}
   }
 
   function getAlluuids() public view returns (uint256) {

--- a/contracts/mtp/StandaloneMTP.sol
+++ b/contracts/mtp/StandaloneMTP.sol
@@ -6,7 +6,10 @@ import "@openzeppelin/contracts-ethereum-package/contracts/ownership/Ownable.sol
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/IERC721Full.sol";
 
 
+//import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+
 contract StandaloneMTP is Initializable, Ownable {
+  //using SafeMath for uint256;
   struct Token {
     bytes32 _mtp_uuid;
     address _token_address;
@@ -75,9 +78,10 @@ contract StandaloneMTP is Initializable, Ownable {
   }
 
   function interact(
+    bytes32 uuid,
     address contract_address,
     string memory function_call,
-    bytes32 uuid
+    uint256[] memory val
   ) public {
     require(!tokens[uuid]._withdraw, "Token was withdrawed");
     require(
@@ -87,7 +91,6 @@ contract StandaloneMTP is Initializable, Ownable {
 
     _setDC(contract_address);
     bytes4 sig = bytes4(keccak256(bytes(function_call)));
-    uint256 val = tokens[uuid]._token_id;
     _contract.call(abi.encodePacked(sig, val));
     //assembly {
     //let ptr := mload(0x40)

--- a/contracts/nft/NFT.sol
+++ b/contracts/nft/NFT.sol
@@ -3,9 +3,11 @@ pragma solidity ^0.5.12;
 import "@openzeppelin/upgrades/contracts/Initializable.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/ERC721Full.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC721/ERC721Mintable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 
 
 contract NFT is Initializable, ERC721Full, ERC721Mintable {
+  using SafeMath for uint256;
   mapping(uint256 => uint256) private _counts;
 
   function initialize(string memory name, string memory symbol)
@@ -18,19 +20,19 @@ contract NFT is Initializable, ERC721Full, ERC721Mintable {
     ERC721Mintable.initialize(msg.sender);
   }
 
-  //function mintUniuqeToken()public{
-  //ERC721Mintable.mint(msg.sender, ERC721Enumerable.totalSupply());
-  //}
-
   function increment(uint256 tokenId) public {
-    require(ERC721.ownerOf(tokenId) == msg.sender, "Must be token owner");
-    _counts[tokenId] += 1;
+    require(ERC721.ownerOf(tokenId) == msg.sender, "must be token owner");
+    _counts[tokenId] = SafeMath.add(_counts[tokenId], 1);
   }
 
   function decrement(uint256 tokenId) public {
     require(ERC721.ownerOf(tokenId) == msg.sender, "Must be token owner");
-    require(_counts[tokenId] >= 1, "Count must be greater or equal to 1");
-    _counts[tokenId] -= 1;
+    _counts[tokenId] = SafeMath.sub(_counts[tokenId], 1);
+  }
+
+  function addByNumber(uint256 tokenId, uint256 num) public {
+    require(ERC721.ownerOf(tokenId) == msg.sender, "must be token owner");
+    _counts[tokenId] = SafeMath.add(_counts[tokenId], num);
   }
 
   function getCounts(uint256 tokenId) public view returns (uint256) {

--- a/test/StandaloneMTP.test.js
+++ b/test/StandaloneMTP.test.js
@@ -33,6 +33,7 @@ describe("StandaloneMTP", function() {
         from: alice
       });
       await this.token.increment(firstTokenId, { from: bob });
+      await this.token.addByNumber(secondTokenId, 5, { from: alice });
     });
     it("create token", async function() {
       expect(await this.token.balanceOf(alice)).to.be.bignumber.equal("1");
@@ -47,7 +48,7 @@ describe("StandaloneMTP", function() {
         "1"
       );
       expect(await this.token.getCounts(secondTokenId)).to.be.bignumber.equal(
-        "0"
+        "5"
       );
     });
     it("deploy mtp", async function() {
@@ -99,9 +100,10 @@ describe("StandaloneMTP", function() {
         "1"
       );
       await this.mtp.interact(
+        Token._mtp_uuid,
         await this.token.address,
         "increment(uint256)",
-        Token._mtp_uuid,
+        [Token._token_id],
         {
           from: alice
         }
@@ -109,9 +111,10 @@ describe("StandaloneMTP", function() {
 
       await expectRevert(
         this.mtp.interact(
+          Token._mtp_uuid,
           await this.token.address,
           "increment(uint256)",
-          Token._mtp_uuid,
+          [Token._token_id],
           { from: bob }
         ),
         "Caller must be current holder"
@@ -121,15 +124,28 @@ describe("StandaloneMTP", function() {
         "2"
       );
       await this.mtp.interact(
+        Token._mtp_uuid,
         await this.token.address,
         "decrement(uint256)",
-        Token._mtp_uuid,
+        [Token._token_id],
         {
           from: alice
         }
       );
       expect(await this.token.getCounts(firstTokenId)).to.be.bignumber.equal(
         "1"
+      );
+      await this.mtp.interact(
+        Token._mtp_uuid,
+        await this.token.address,
+        "addByNumber(uint256,uint256)",
+        [Token._token_id, 5],
+        {
+          from: alice
+        }
+      );
+      expect(await this.token.getCounts(firstTokenId)).to.be.bignumber.equal(
+        "6"
       );
     });
   });


### PR DESCRIPTION
Standalone's interact function now supports dynamic params
currently only supports uint256 array

```
interact(address contract_address, string function_call, uint256[] val)
```

a sample call from web3 looks like this:
```
const uuids = await this.mtp.getAlluuids();
      await this.mtp.interact(
        await this.token.address,
        "increment(uint256)",
        [uuids[0]],
        {
          from: alice
        }
      );

const num = 5;
      await this.mtp.interact(
        await this.token.address,
        "addByNumber(uint256,uint256)",
        [uuids[0],num],
        {
          from: alice
        }
      );
```